### PR TITLE
feat: validate files (video and thumbnail)

### DIFF
--- a/src/app/_components/create-post-modal/video-input.tsx
+++ b/src/app/_components/create-post-modal/video-input.tsx
@@ -35,7 +35,7 @@ export default function UploadVideo({
       <div className="border-primary hover:bg-primary/5 cursor-pointer rounded-xl border-2 border-dashed p-8 text-center transition-colors">
         <Input
           type="file"
-          accept="video/*"
+          accept="video/mp4,video/mov,video/webm"
           onChange={handleVideoChange}
           className="hidden"
           {...props}


### PR DESCRIPTION
closes #33 
This pull request introduces stricter validation for video and thumbnail uploads in the `CreateRegularPost` component, ensuring that uploaded files meet specific size and format requirements. Additionally, it updates the file input fields to enforce these restrictions at the UI level.

### Validation Enhancements:

* Added `allowedVideoTypesEnum` and `allowedThumbnailTypesEnum` to define acceptable file types for videos (`mp4`, `webm`, `mov`) and thumbnails (`jpeg`, `png`, `webp`) respectively in `basicInfoSchema`.
* Enhanced `basicInfoSchema` with a `superRefine` method to:
  - Enforce a maximum size of 100MB for videos and 5MB for thumbnails.
  - Validate that uploaded files match the allowed formats.

### UI Updates:

* Updated the `accept` attribute in the thumbnail file input to restrict uploads to `jpeg`, `png`, and `webp` formats.
* Updated the `accept` attribute in the video file input to restrict uploads to `mp4`, `mov`, and `webm` formats.