### PR TITLE
fix: video remove button only removes preview, not file from form

### DIFF
--- a/src/app/_components/create-post-modal/video-input.tsx
+++ b/src/app/_components/create-post-modal/video-input.tsx
@@ -66,6 +66,9 @@ export default function UploadVideo({
           className="absolute top-2 right-2 h-8 w-8 rounded-full"
           onClick={() => {
             setVideoPreview(null);
+            handleVideoChange({
+              target: { files: null },
+            } as unknown as React.ChangeEvent<HTMLInputElement>);
           }}
         >
           <X className="h-4 w-4" />


### PR DESCRIPTION
closes #21 
This pull request includes a small but important change to the `UploadVideo` component in `video-input.tsx`. The change ensures that when the video preview is cleared, the `handleVideoChange` function is also triggered with a `null` file input to properly reset the video state.